### PR TITLE
Fix for Multiple editors bug

### DIFF
--- a/src/knockout-froala.js
+++ b/src/knockout-froala.js
@@ -74,9 +74,16 @@ options.events = {
    * @api public
    */
 
-  function update( element, value ) {
+  function update( element, value, bindings ) {
   
     var modelValue = unwrap( value() );
+
+    //if froalaInstance defined, use that for the editor instance
+    var allBindings = unwrap( bindings() );
+    if(allBindings.froalaInstance && ko.isWriteableObservable( allBindings.froalaInstance ) ) {
+      editorInstance = allBindings.froalaInstance();
+    }
+
  
     if( editorInstance == null  ) {
       return;

--- a/src/knockout-froala.js
+++ b/src/knockout-froala.js
@@ -58,7 +58,7 @@ options.events = {
     
 
     // cleanup editor, when dom node is removed
-    ko.utils.domNodeDisposal.addDisposeCallback( element, destroy( element ) );
+    ko.utils.domNodeDisposal.addDisposeCallback( element, destroy( element, bindings ) );
 
     // do not handle child nodes
     return { controlsDescendantBindings: true };
@@ -107,8 +107,14 @@ options.events = {
    * @api private
    */
 
-  function destroy( element ) {
+  function destroy( element, bindings ) {
     return function() {
+      //if froalaInstance defined, use that for the editor instance
+      var allBindings = unwrap( bindings() );
+      if(allBindings.froalaInstance && ko.isWriteableObservable( allBindings.froalaInstance ) ) {
+        editorInstance = allBindings.froalaInstance();
+      }
+
       if( editorInstance!=null ) {
         editorInstance.destroy();
       }

--- a/src/knockout-froala.js
+++ b/src/knockout-froala.js
@@ -28,6 +28,11 @@
     var processUpdateEvent = function (e) {
     
       if (ko.isWriteableObservable(model)) {
+        //if froalaInstance defined, use that for the editor instance
+        if(allBindings.froalaInstance && ko.isWriteableObservable( allBindings.froalaInstance ) ) {
+          editorInstance = allBindings.froalaInstance();
+        }
+        
         if(editorInstance!=null)
         {
           var editorValue = editorInstance.html.get();


### PR DESCRIPTION
Fix for issue https://github.com/froala/knockout-froala/issues/16

With this change need to add binding to froalaInstance:
```
<textarea data-bind="value:questionLabel, froala: questionLabel, froalaOptions: $root.editorOptions, froalaInstance:ko.observable()"></textarea>
```